### PR TITLE
fix license issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/Pencil-Yao/efficient-sm2"
 
 [dependencies]
 rand = "0.8"
-libsm = "0.3.0"
+libsm = { git = "https://github.com/citahub/libsm.git", branch = "master" }
 
 [dev-dependencies]
 hex = "0.3"


### PR DESCRIPTION
Since the license for libsm 0.3.0 is GPL3, the better idea is use this lib which use the apache2 license.
Also, I think using ecmul in this lib is more efficient, maybe you won't really need that lib.